### PR TITLE
Bug found: scFontFam

### DIFF
--- a/font-family.sublime-snippet
+++ b/font-family.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
   <content>
     <![CDATA[
-    font-family:${1:arial,sans-serif;}font-size:${2:14px;}font-weight:${3:normal;};mso-line-height-rule:exactly;line-height:${4:1.5;};color:${5:#000001;};
+    font-family:${1:arial,sans-serif};font-size:${2:14px};font-weight:${3:normal};mso-line-height-rule:exactly;line-height:${4:1.5};color:${5:#000001};
     ]]>
   </content>
     <tabTrigger>scFontFam</tabTrigger>


### PR DESCRIPTION
Noticed a bug with scFontFam, there were too many semi-colons after some attributes.
